### PR TITLE
스택 제거를 통한 원활한 앱 종료 환경 개선

### DIFF
--- a/app/src/main/java/com/kotlin/practice2/view/SelectActivity.kt
+++ b/app/src/main/java/com/kotlin/practice2/view/SelectActivity.kt
@@ -41,14 +41,17 @@ class SelectActivity : AppCompatActivity() {
             viewModel.saveSelectedCoinList(selectRVAdapter.selectedCoinList)
         }
 
-        viewModel.saved.observe(this){
-            if(it.equals("done")){
-                val intent = Intent(this, MainActivity::class.java)
+        viewModel.saved.observe(this) {
+            if (it.equals("done")) {
+                val intent = Intent(this, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                }
                 startActivity(intent)
 
                 saveInterestCoinDataPeriodic()
             }
         }
+
 
     }
 


### PR DESCRIPTION
이슈에 댓글을 달았던 내용을 개선해 보았습니다. 
말씀드린 암호화폐의 종목을 고르고 메인페이지로 넘어가서 종료를 하려고 뒤로 가면 다시 암호화폐의 종목을 고르는 페이지로 넘어가지는 부분을 SelectActivity의 파일 내용에서 보기와 같이 수정하였습니다.

viewModel.saved.observe(this) {
            if (it.equals("done")) {
                val intent = Intent(this, MainActivity::class.java).apply {
                    flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
                }
                startActivity(intent)

                saveInterestCoinDataPeriodic()
            }
        }
위 코드는 페이지에 넘어갈 경우 스택을 제거하면서 넘어가는 코드이며 결과로는 암호화폐의 종목을 고르고 메인페이지에서 종료를 하면 정상적으로 앱이 종료되는 것을 확인할 수 있었습니다.